### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,15 +50,15 @@ Imports:
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
     Rdpack,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.2.0)
 LinkingTo:
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 LazyData: true
 Suggests: 

--- a/inst/stan/phacking_rtma.stan
+++ b/inst/stan/phacking_rtma.stan
@@ -1,6 +1,6 @@
 functions{
 
-	real jeffreys_prior(real mu, real tau, int k, real[] sei, real[] tcrit){
+	real jeffreys_prior(real mu, real tau, int k, array[] real sei, array[] real tcrit){
 
     // variables that will be recalculated for each observation
 		real kmm;
@@ -50,9 +50,9 @@ functions{
 
 data{
 	int<lower=0> k;
-  real sei[k];
-  real tcrit[k];
-	real y[k];
+  array[k] real sei;
+  array[k] real tcrit;
+	array[k] real y;
 }
 
 parameters{


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
